### PR TITLE
Area screenshots improvements with multiple surfaces

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.4.7
+  Features:
+    - Area screenshot improvements with multiple surfaces. The selection rectangle now draws on the right surface, and the screenshot will be taken on the surface with the selection, instead of the surface you are looking at.
+---------------------------------------------------------------------------------------------------
 Version: 2.4.6
   Bugfixes:
     - Fixed some logging issues

--- a/control.lua
+++ b/control.lua
@@ -464,6 +464,10 @@ local function on_left_click(event)
     if global.snip[event.player_index].doesSelection then
         log(l.info("left click event fired while doing selection by player " .. event.player_index))
         global.snip[event.player_index].areaLeftClick = event.cursor_position
+        if game.get_player(event.player_index).surface.name ~= global.snip[event.player_index].surface_name then
+            -- Surface has changed, new area
+            global.snip[event.player_index].areaRightClick = nil
+        end
 	    handleAreaChange(event.player_index)
     end
 end
@@ -472,6 +476,10 @@ local function on_right_click(event)
     if global.snip[event.player_index].doesSelection then
         log(l.info("right click event fired while doing selection by player " .. event.player_index))
         global.snip[event.player_index].areaRightClick = event.cursor_position
+        if game.get_player(event.player_index).surface.name ~= global.snip[event.player_index].surface_name then
+            -- Surface has changed, new area
+            global.snip[event.player_index].areaLeftClick = nil
+        end
 		handleAreaChange(event.player_index)
     end
 end

--- a/scripts/shooter.lua
+++ b/scripts/shooter.lua
@@ -131,6 +131,7 @@ function shooter.renderAreaScreenshot(index)
 		log(l.debug("output name: " .. (global.snip[index].outputName or "screenshot")))
 		log(l.debug("format:      " .. global.snip[index].output_format_index))
 		log(l.debug("jpg quality: " .. global.snip[index].jpg_quality))
+		log(l.debug("surface_name:" .. global.snip[index].surface_name))
 	end
 
 	local width = global.snip[index].area.right - global.snip[index].area.left
@@ -142,9 +143,16 @@ function shooter.renderAreaScreenshot(index)
 	local posX = global.snip[index].area.left + width / 2
 	local posY = global.snip[index].area.top + heigth / 2
 
+	local surface
+	if global.snip[index].surface_name then
+		surface = game.surfaces[global.snip[index].surface_name]
+	else
+		surface = game.get_player(index).surface
+	end
+
 	local dstate = global.snip[index].daytime_state
 	if dstate == nil or dstate == "none" then
-		dstate = game.get_player(index).surface.daytime
+		dstate = surface.daytime
 	elseif dstate == "left" then
 		dstate = 0
 	else
@@ -160,6 +168,7 @@ function shooter.renderAreaScreenshot(index)
 	game.take_screenshot{
 		resolution = {resX, resY},
 		position = {posX, posY},
+		surface = surface,
 		zoom = zoom,
 		by_player = index,
 		path = path,

--- a/scripts/snip.lua
+++ b/scripts/snip.lua
@@ -22,6 +22,9 @@ function snip.resetArea(index)
     if global.snip[index].filesize then
         global.snip[index].filesize = nil
     end
+    if global.snip[index].surface then
+        global.snip[index].surface = nil
+    end
 end
 
 function snip.calculateArea(index)
@@ -91,7 +94,10 @@ function snip.calculateArea(index)
     global.snip[index].area.bottom = bottom
     global.snip[index].area.width = width
     global.snip[index].area.height = height
-    
+
+    local surface_name = game.get_player(index).surface.name
+    global.snip[index].surface_name = surface_name
+
     if global.snip[index].rec then
         rendering.destroy(global.snip[index].rec)
     end
@@ -102,7 +108,7 @@ function snip.calculateArea(index)
         left_top = {left, top},
         right_bottom = {right, bottom},
         players = {index},
-        surface = "nauvis"
+        surface = surface_name
     }
     
 end


### PR DESCRIPTION
Fixes 2 issues:
1) The selection rectangle always draws on Nauvis instead of the surface you were at.
2) The screenshot is always taken on the surface you are looking at, instead of where you draw the selection rectangle.